### PR TITLE
load persisted data on graph elements in KGraph Synthesis

### DIFF
--- a/plugins/de.cau.cs.kieler.graphs.klighd/src/de/cau/cs/kieler/graphs/klighd/syntheses/KGraphDiagramSynthesis.xtend
+++ b/plugins/de.cau.cs.kieler.graphs.klighd/src/de/cau/cs/kieler/graphs/klighd/syntheses/KGraphDiagramSynthesis.xtend
@@ -19,6 +19,7 @@ import de.cau.cs.kieler.klighd.SynthesisOption
 import de.cau.cs.kieler.klighd.kgraph.EMapPropertyHolder
 import de.cau.cs.kieler.klighd.kgraph.KEdge
 import de.cau.cs.kieler.klighd.kgraph.KGraphData
+import de.cau.cs.kieler.klighd.kgraph.KGraphElement
 import de.cau.cs.kieler.klighd.kgraph.KNode
 import de.cau.cs.kieler.klighd.kgraph.KPort
 import de.cau.cs.kieler.klighd.kgraph.util.KGraphDataUtil
@@ -64,9 +65,10 @@ class KGraphDiagramSynthesis extends AbstractStyledDiagramSynthesis<KNode> {
 
     // The next two definitions are used to load possibly persisted klighd information
     // that is ignored by ELK, e.g. the expansion state of nodes
-    private static val PREDICATE_IS_KGRAPHDATA = new Predicate<EMapPropertyHolder>() {
+    private static val PREDICATE_IS_KGRAPH_OR_DATA = new Predicate<EMapPropertyHolder>() {
         override apply(EMapPropertyHolder input) {
-            return input instanceof KGraphData;
+            return input instanceof KGraphData
+                || input instanceof KGraphElement;
         }
     }
     private static val KNOWN_PROPS = ImmutableList.of(KlighdProperties.EXPAND,
@@ -158,7 +160,7 @@ class KGraphDiagramSynthesis extends AbstractStyledDiagramSynthesis<KNode> {
         //  but until now nobody knows about any persisted entries that originate from KLighD.
         // First, this might be the expansion state of nodes. Second, also KRendering elements
         //  may carry persisted entries that have to be parsed before we build the view model.
-        KGraphDataUtil.loadDataElements(result, PREDICATE_IS_KGRAPHDATA, KNOWN_PROPS)
+        KGraphDataUtil.loadDataElements(result, PREDICATE_IS_KGRAPH_OR_DATA, KNOWN_PROPS)
 
         // Evaluate the defaults property
         try {


### PR DESCRIPTION
when viewing kgx files, previously no persisted options such as layout options and other KLighD properties were applied to the view model. This fixes that issue.