### PR TITLE
Update Deprecated Actions. Bump update-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: MAVEN_OPTS="-Xmx2048M" mvn --update-snapshots clean verify -P pragmatics --file build/pom.xml
 
       - name: Archive Pragmatics Repository Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Pragmatics Repository Artifact
           path: build/de.cau.cs.kieler.pragmatics.repository/target/repository/


### PR DESCRIPTION
see https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/