### PR TITLE
fix missing dependencies for gml

### DIFF
--- a/plugins/de.cau.cs.kieler.formats.gml/META-INF/MANIFEST.MF
+++ b/plugins/de.cau.cs.kieler.formats.gml/META-INF/MANIFEST.MF
@@ -8,7 +8,9 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtend.lib;bundle-version="2.7.0",
  org.eclipse.elk.graph;bundle-version="0.1.0",
  de.cau.cs.kieler.formats,
- org.eclipse.elk.core
+ org.eclipse.elk.core,
+ org.eclipse.emf.common,
+ org.eclipse.emf.ecore
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: 
  de.cau.cs.kieler.formats.gml

--- a/plugins/de.cau.cs.kieler.formats.json/META-INF/MANIFEST.MF
+++ b/plugins/de.cau.cs.kieler.formats.json/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-Name: KIELER Support for the JSON Format
 Bundle-Vendor: Kiel University
 Bundle-Version: 0.51.1.qualifier
 Bundle-SymbolicName: de.cau.cs.kieler.formats.json;singleton:=true
-Require-Bundle: de.cau.cs.kieler.formats,
+Require-Bundle: com.google.gson,
+ de.cau.cs.kieler.formats,
  org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.graph.json

--- a/plugins/de.cau.cs.kieler.kiml.export/META-INF/MANIFEST.MF
+++ b/plugins/de.cau.cs.kieler.kiml.export/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Require-Bundle: com.google.guava;bundle-version="15.0.0",
  org.eclipse.ui,
  org.eclipse.ui.ide,
  org.eclipse.core.runtime,
+ org.eclipse.elk.core,
  org.eclipse.elk.core.service,
  org.eclipse.elk.graph,
  de.cau.cs.kieler.formats


### PR DESCRIPTION
Fixes build system of Pragmatics to be compatible with ELK's current master again.
Adds dependencies that were previously present due to re-exported dependencies in ELK, which have now been removed in https://github.com/eclipse-elk/elk/pull/1074. 
